### PR TITLE
Add AVIF dependency to support 16 KB page size requirement

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -39,7 +39,10 @@ dependencies {
     annotationProcessor 'com.github.bumptech.glide:compiler:4.16.0'
 
     // AVIF support
-    implementation 'com.github.bumptech.glide:avif-integration:4.16.0'
+    implementation 'org.aomedia.avif.android:avif:1.3.0.841110fd'
+    implementation ("com.github.bumptech.glide:avif-integration:4.16.0") {
+        exclude group: 'org.aomedia.avif.android', module: 'avif'
+    }
 
     // SVG support
     api 'com.caverock:androidsvg-aar:1.4'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-blasted-image",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "A simple yet powerful image component for React Native, powered by Glide and SDWebImage",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
## Description

This PR updates the `build.gradle` dependencies to align with Google Play’s new 16 KB page size requirement. Specifically, it introduces explicit AVIF support to ensure compatibility and optimize image handling in React Native Blasted Image.

Google Play enforces a 16 KB page size requirement starting with the latest Android app submissions. Without explicitly including the updated AVIF dependency, apps may fail Play Store checks. This change ensures compliance while maintaining existing image rendering features.

## Changes

* Added AVIF dependency:
```
implementation 'org.aomedia.avif.android:avif:1.3.0.841110fd'
```

* Updated Glide integration to include AVIF support:
```
implementation ("com.github.bumptech.glide:avif-integration:4.16.0") {
    exclude group: 'org.aomedia.avif.android', module: 'avif'
}
```

## Notes

* This update is non-breaking and backward-compatible.
* Ensures future-proof image support in line with Play Store requirements.